### PR TITLE
no x86intrin.h for __APPLE__

### DIFF
--- a/non_portable.h
+++ b/non_portable.h
@@ -44,7 +44,10 @@
   }
 #else
   // --------------------- Efficient/Non portable definitions -----------------
-  #ifdef __GNUC__    
+  #ifdef __APPLE__
+    __INLINE__ int popcnt_u32(unsigned int m32) { return __builtin_popcount(m32);}
+    __INLINE__ int bsf_u32(unsigned int m32) { return  __builtin_ctz(m32);}
+  #elif __GNUC__
     #include <x86intrin.h>       // for INTEL SSE intrinsics
     __INLINE__ int popcnt_u32(unsigned int m32) { return __builtin_popcount(m32);}
     __INLINE__ int bsf_u32(unsigned int m32) { return  __builtin_ctz(m32);} 


### PR DESCRIPTION
# include <x86intrin.h>  is not available on iOS device (ARM). Apple-specific (iOS and Mac OS) optimisations are grouped inside **APPLE** (instead of **GNUC**).
